### PR TITLE
disable Ivy and try to do a full template check

### DIFF
--- a/projects/my-lib/tsconfig.lib.prod.json
+++ b/projects/my-lib/tsconfig.lib.prod.json
@@ -5,6 +5,14 @@
     "declarationMap": false
   },
   "angularCompilerOptions": {
-    "compilationMode": "partial"
+    "compilationMode": "partial",
+    "enableIvy": false,
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true,
+    "enableResourceInlining": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
   }
 }


### PR DESCRIPTION
@pavankjadda this is what I attempted to do. You can already see, by just disabling Ivy, that some meta information is missing
```
Can't resolve all parameters for CookieService in PATH_TO_REPO/ngx-cookie-service-bug-145/node_modules/ngx-cookie-service/lib/cookie.service.d.ts: (?, [object Object]).
```

When then trying to attempt to do a full template check and enable strict templates, the `Maximum call stack size exceeded` appears.

I assume you could just add the compiler flag to emit the meta data, as suggested in:

- https://stackoverflow.com/questions/37997824/error-when-trying-to-inject-a-service-into-an-angular-component-exception-can
- https://stackoverflow.com/questions/60149052/this-constructor-is-not-compatible-with-angular-dependency-injection-because-its/64798796?noredirect=1#comment119411559_64798796

Question remains, if you want to support legacy view. It would help me at least 😬 